### PR TITLE
Harden Azure Landing Zone CLI networking

### DIFF
--- a/AzureLandingZoneforNonprofits/Install-AzureLandingZone.ps1
+++ b/AzureLandingZoneforNonprofits/Install-AzureLandingZone.ps1
@@ -1314,6 +1314,9 @@ function New-CustomerSummary {
       networkResourceGroupName = Get-OutputValue -Outputs $outputs -Name 'networkResourceGroupName'
       logAnalyticsWorkspaceResourceId = Get-OutputValue -Outputs $outputs -Name 'logAnalyticsWorkspaceResourceId'
       keyVaultResourceId = Get-OutputValue -Outputs $outputs -Name 'keyVaultResourceId'
+      vnetResourceId = Get-OutputValue -Outputs $outputs -Name 'vnetResourceId'
+      applicationSubnetResourceId = Get-OutputValue -Outputs $outputs -Name 'applicationSubnetResourceId'
+      applicationNetworkSecurityGroupResourceId = Get-OutputValue -Outputs $outputs -Name 'applicationNetworkSecurityGroupResourceId'
       followUpActions = $followUpActions
     }
   }

--- a/AzureLandingZoneforNonprofits/cli-package-manifest.json
+++ b/AzureLandingZoneforNonprofits/cli-package-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": "1.0",
   "packageName": "azure-landing-zone-cli",
   "publicSurface": "cli-package",
-  "generatedAtUtc": "2026-05-20T07:38:11.8913138Z",
+  "generatedAtUtc": "2026-07-16T20:57:16.5324167Z",
   "includedItems": [
     {
       "sourcePath": "cli/Install-AzureLandingZone.ps1",

--- a/AzureLandingZoneforNonprofits/infra/entrypoints/direct/expanded-platform.bicep
+++ b/AzureLandingZoneforNonprofits/infra/entrypoints/direct/expanded-platform.bicep
@@ -56,7 +56,7 @@ param platformManagementGroupId string = ''
 @description('Reserve the GatewaySubnet in the hub VNet so a VPN gateway, ExpressRoute gateway, or Azure Virtual WAN can be added later. This deployment reserves the subnet only; it does not create the gateway resource, public IP, or connection objects.')
 param reserveGatewaySubnet bool = false
 
-@description('Optional private DNS and Key Vault private endpoints flag.')
+@description('Enable private DNS and a private endpoint for the shared platform Key Vault, and disable its public endpoint. When false, the public endpoint remains enabled but the Key Vault firewall denies all public IP and virtual-network traffic by default.')
 param enablePrivateDnsAndEndpoints bool = false
 
 @description('Enable purge protection on the Expanded Platform management Key Vault. Defaults to true for steady-state platform environments; set false for evaluation deployments that need immediate teardown.')

--- a/AzureLandingZoneforNonprofits/infra/entrypoints/direct/foundation-subscription.bicep
+++ b/AzureLandingZoneforNonprofits/infra/entrypoints/direct/foundation-subscription.bicep
@@ -38,7 +38,7 @@ param partnerOperatorsGroupObjectId string = ''
 @description('Deploy the optional simple Foundation network baseline.')
 param enableSimpleNetwork bool = false
 
-@description('Enable private DNS and a private endpoint for the shared platform Key Vault. In Foundation this requires the simple network baseline.')
+@description('Enable private DNS and a private endpoint for the shared platform Key Vault, and disable its public endpoint. In Foundation this requires the simple network baseline. When false, the public endpoint remains enabled but the Key Vault firewall denies all public IP and virtual-network traffic by default.')
 param enablePrivateDnsAndEndpoints bool = false
 
 @description('Enable purge protection on the Foundation platform Key Vault. Defaults to false so evaluation deployments stay reversible (purge protection is irrevocable for 7 days once turned on). Enable this once the environment will hold real platform secrets that must survive accidental deletion.')
@@ -161,6 +161,8 @@ output networkResourceGroupName string = foundationPlatformBaseline.outputs.netw
 output logAnalyticsWorkspaceResourceId string = foundationPlatformBaseline.outputs.logAnalyticsWorkspaceResourceId
 output keyVaultResourceId string = foundationPlatformBaseline.outputs.keyVaultResourceId
 output vnetResourceId string = foundationPlatformBaseline.outputs.vnetResourceId
+output applicationSubnetResourceId string = foundationPlatformBaseline.outputs.applicationSubnetResourceId
+output applicationNetworkSecurityGroupResourceId string = foundationPlatformBaseline.outputs.applicationNetworkSecurityGroupResourceId
 output keyVaultPrivateEndpointResourceId string = foundationPlatformBaseline.outputs.keyVaultPrivateEndpointResourceId
 output securityKeyVaultPrivateHardeningStatus string = foundationSecurity.outputs.keyVaultPrivateHardeningStatus
 output governanceBudgetStatus string = foundationBudget.outputs.budgetStatus

--- a/AzureLandingZoneforNonprofits/infra/modules/monitoring/keyvault-diagnostics.bicep
+++ b/AzureLandingZoneforNonprofits/infra/modules/monitoring/keyvault-diagnostics.bicep
@@ -9,7 +9,7 @@ param logAnalyticsWorkspaceResourceId string
 @description('Diagnostic setting name.')
 param diagnosticSettingName string = 'alz-kv-diag'
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' existing = {
   name: keyVaultName
 }
 

--- a/AzureLandingZoneforNonprofits/infra/modules/networking/README.md
+++ b/AzureLandingZoneforNonprofits/infra/modules/networking/README.md
@@ -13,8 +13,10 @@ Implementation notes:
 
 - Foundation networking is disabled by default.
 - Foundation networking never creates hub-and-spoke resources.
+- The Foundation application subnet is private and uses a no-cost NSG that blocks internet ingress and egress. Workload teams must add narrowly scoped allow rules and an explicit outbound method when their workloads require them.
 - Expanded Platform always creates one dedicated hub VNet in the connectivity subscription.
 - Optional Expanded Platform networking features are bounded to GatewaySubnet reservation and Key Vault private connectivity.
 - The deployment does not create peering between Foundation and Expanded Platform. Organizations that want to peer an existing Foundation VNet to a new Expanded hub can follow the manual peering runbook (`docs/runbooks/foundation-to-expanded-peering.md`).
 - Private connectivity is limited to the shared platform Key Vault in this implementation.
 - In Foundation, private Key Vault connectivity requires the simple network baseline.
+- NAT Gateway, route-based centralized egress, Azure Firewall, and paid DDoS protection remain outside the Foundation baseline.

--- a/AzureLandingZoneforNonprofits/infra/modules/networking/foundation-network-profile.bicep
+++ b/AzureLandingZoneforNonprofits/infra/modules/networking/foundation-network-profile.bicep
@@ -33,9 +33,14 @@ param applicationSubnetAddressPrefix string = '10.20.1.0/24'
 param privateEndpointsSubnetAddressPrefix string = '10.20.2.0/24'
 
 var privateKeyVaultConnectivityEnabled = enableSimpleNetwork && enablePrivateDnsAndEndpoints && !empty(keyVaultResourceId)
-var networkingFollowUpActions = enablePrivateDnsAndEndpoints && !enableSimpleNetwork ? [
-  'Foundation private Key Vault connectivity requires the simple network baseline. Enable simple networking or disable private connectivity for Key Vault.'
-] : []
+var networkingFollowUpActions = concat(
+  enableSimpleNetwork ? [
+    'The Foundation application subnet blocks internet ingress and egress by default. Before deploying workloads, define workload-specific segmentation, required NSG allow rules, and an explicit outbound connectivity method when internet access is needed.'
+  ] : [],
+  enablePrivateDnsAndEndpoints && !enableSimpleNetwork ? [
+    'Foundation private Key Vault connectivity requires the simple network baseline. Enable simple networking or disable private connectivity for Key Vault.'
+  ] : []
+)
 
 resource foundationNetworkResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = if (enableSimpleNetwork) {
   name: networkResourceGroupName
@@ -61,6 +66,7 @@ module foundationNetworkResources 'foundation-network-resources.bicep' = if (ena
 output networkResourceGroupName string = enableSimpleNetwork ? foundationNetworkResourceGroup.name : ''
 output vnetResourceId string = enableSimpleNetwork ? foundationNetworkResources!.outputs.vnetResourceId : ''
 output applicationSubnetResourceId string = enableSimpleNetwork ? foundationNetworkResources!.outputs.applicationSubnetResourceId : ''
+output applicationNetworkSecurityGroupResourceId string = enableSimpleNetwork ? foundationNetworkResources!.outputs.applicationNetworkSecurityGroupResourceId : ''
 output privateEndpointsSubnetResourceId string = privateKeyVaultConnectivityEnabled ? foundationNetworkResources!.outputs.privateEndpointsSubnetResourceId : ''
 output keyVaultPrivateEndpointResourceId string = privateKeyVaultConnectivityEnabled ? foundationNetworkResources!.outputs.keyVaultPrivateEndpointResourceId : ''
 output keyVaultPrivateDnsZoneResourceId string = privateKeyVaultConnectivityEnabled ? foundationNetworkResources!.outputs.keyVaultPrivateDnsZoneResourceId : ''

--- a/AzureLandingZoneforNonprofits/infra/modules/networking/foundation-network-resources.bicep
+++ b/AzureLandingZoneforNonprofits/infra/modules/networking/foundation-network-resources.bicep
@@ -27,6 +27,7 @@ param privateEndpointsSubnetAddressPrefix string = '10.20.2.0/24'
 
 var foundationVnetName = '${deploymentPrefix}-vnet-001'
 var applicationSubnetName = 'application'
+var applicationNetworkSecurityGroupName = '${deploymentPrefix}-app-nsg-001'
 var privateEndpointsSubnetName = 'private-endpoints'
 
 module tagInheritance '../governance/resource-group-tag-inheritance.bicep' = {
@@ -53,12 +54,56 @@ resource foundationVnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   }
 }
 
+resource applicationNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: applicationNetworkSecurityGroupName
+  location: primaryLocation
+  tags: tags
+}
+
+// Keep baseline rules as child resources so their ownership is explicit and the
+// parent NSG doesn't declare a complete inline rule collection. Always review
+// what-if before rerunning against an NSG with workload-specific rules.
+resource denyInternetInboundRule 'Microsoft.Network/networkSecurityGroups/securityRules@2024-05-01' = {
+  parent: applicationNetworkSecurityGroup
+  name: 'DenyInternetInbound'
+  properties: {
+    description: 'Blocks unsolicited internet ingress to future Foundation workloads.'
+    protocol: '*'
+    sourcePortRange: '*'
+    destinationPortRange: '*'
+    sourceAddressPrefix: 'Internet'
+    destinationAddressPrefix: '*'
+    access: 'Deny'
+    priority: 4095
+    direction: 'Inbound'
+  }
+}
+
+resource denyInternetOutboundRule 'Microsoft.Network/networkSecurityGroups/securityRules@2024-05-01' = {
+  parent: applicationNetworkSecurityGroup
+  name: 'DenyInternetOutbound'
+  properties: {
+    description: 'Requires future Foundation workloads to use an explicitly approved outbound design.'
+    protocol: '*'
+    sourcePortRange: '*'
+    destinationPortRange: '*'
+    sourceAddressPrefix: '*'
+    destinationAddressPrefix: 'Internet'
+    access: 'Deny'
+    priority: 4096
+    direction: 'Outbound'
+  }
+}
+
 resource applicationSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
   parent: foundationVnet
   name: applicationSubnetName
   properties: {
     addressPrefix: applicationSubnetAddressPrefix
     defaultOutboundAccess: false
+    networkSecurityGroup: {
+      id: applicationNetworkSecurityGroup.id
+    }
   }
 }
 
@@ -70,6 +115,9 @@ resource privateEndpointsSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-
     defaultOutboundAccess: false
     privateEndpointNetworkPolicies: 'Disabled'
   }
+  dependsOn: [
+    applicationSubnet
+  ]
 }
 
 resource keyVaultPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (enablePrivateDnsAndEndpoints && !empty(keyVaultResourceId)) {
@@ -130,6 +178,7 @@ resource keyVaultPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/private
 
 output vnetResourceId string = foundationVnet.id
 output applicationSubnetResourceId string = applicationSubnet.id
+output applicationNetworkSecurityGroupResourceId string = applicationNetworkSecurityGroup.id
 output privateEndpointsSubnetResourceId string = enablePrivateDnsAndEndpoints ? privateEndpointsSubnet.id : ''
 output keyVaultPrivateEndpointResourceId string = enablePrivateDnsAndEndpoints && !empty(keyVaultResourceId) ? keyVaultPrivateEndpoint.id : ''
 output keyVaultPrivateDnsZoneResourceId string = enablePrivateDnsAndEndpoints && !empty(keyVaultResourceId) ? keyVaultPrivateDnsZone.id : ''

--- a/AzureLandingZoneforNonprofits/infra/modules/security/subscription-security-baseline.bicep
+++ b/AzureLandingZoneforNonprofits/infra/modules/security/subscription-security-baseline.bicep
@@ -20,7 +20,7 @@ var defenderRecommended = defenderBaseline == 'recommended'
 var keyVaultPrivateHardeningStatus = !empty(keyVaultResourceId) ? (enablePrivateDnsAndEndpoints ? (keyVaultPrivateEndpointImplemented ? 'implemented-via-networking-profile' : 'requested-but-not-implemented') : 'not-requested') : 'not-applicable-no-keyvault-in-scope'
 var securityFollowUpActions = concat(
   !empty(keyVaultResourceId) && !enablePrivateDnsAndEndpoints ? [
-    'Key Vault uses public network access by default. Enable private DNS and the Key Vault private endpoint later only when private-only secret access is required or a compliance review requires it.'
+    'Key Vault public endpoint is protected by a deny-by-default firewall with deployment-owned empty allowlists. Manually added firewall rules are removed on redeployment; enable private DNS and the Key Vault private endpoint when persistent data-plane access is required.'
   ] : [],
   !empty(keyVaultResourceId) && enablePrivateDnsAndEndpoints && !keyVaultPrivateEndpointImplemented ? [
     'Key Vault private connectivity was requested, but the selected networking profile did not implement the required private endpoint and private DNS path. Complete the networking prerequisite or disable private-only Key Vault access.'

--- a/AzureLandingZoneforNonprofits/infra/modules/shared/foundation-platform-baseline.bicep
+++ b/AzureLandingZoneforNonprofits/infra/modules/shared/foundation-platform-baseline.bicep
@@ -16,7 +16,7 @@ param serviceOwner string
 @description('Deploy the optional simple Foundation network baseline.')
 param enableSimpleNetwork bool = false
 
-@description('Enable private DNS and a private endpoint for the shared platform Key Vault. In Foundation this requires the simple network baseline.')
+@description('Enable private DNS and a private endpoint for the shared platform Key Vault, and disable its public endpoint. In Foundation this requires the simple network baseline. When false, the Key Vault remains protected by the shared deny-by-default firewall baseline.')
 param enablePrivateDnsAndEndpoints bool = false
 
 @description('Address space for the optional Foundation VNet. Default /22 (1024 addresses) sized for a small NGO and to leave room for future peering without /16 collisions.')
@@ -78,6 +78,7 @@ output logAnalyticsWorkspaceResourceId string = foundationSlice.outputs.logAnaly
 output keyVaultResourceId string = foundationSlice.outputs.keyVaultResourceId
 output vnetResourceId string = foundationNetworking.outputs.vnetResourceId
 output applicationSubnetResourceId string = foundationNetworking.outputs.applicationSubnetResourceId
+output applicationNetworkSecurityGroupResourceId string = foundationNetworking.outputs.applicationNetworkSecurityGroupResourceId
 output privateEndpointsSubnetResourceId string = foundationNetworking.outputs.privateEndpointsSubnetResourceId
 output keyVaultPrivateEndpointResourceId string = foundationNetworking.outputs.keyVaultPrivateEndpointResourceId
 output keyVaultPrivateDnsZoneResourceId string = foundationNetworking.outputs.keyVaultPrivateDnsZoneResourceId

--- a/AzureLandingZoneforNonprofits/infra/modules/shared/resource-group-baseline.bicep
+++ b/AzureLandingZoneforNonprofits/infra/modules/shared/resource-group-baseline.bicep
@@ -24,7 +24,7 @@ param createKeyVault bool = true
 @description('Optional stable seed for the generated Key Vault name. Leave empty to preserve the default deterministic name; set a custom value only when an evaluation deployment must avoid a soft-deleted Key Vault name in the same resource group.')
 param keyVaultNameSeed string = ''
 
-@description('Public network access mode for the shared Key Vault.')
+@description('Public endpoint mode for the shared Key Vault. The Key Vault firewall remains deny-by-default with no public IP or virtual-network allow rules; private endpoint deployments set this to Disabled.')
 param keyVaultPublicNetworkAccess 'Enabled' | 'Disabled' = 'Enabled'
 
 @description('Enable purge protection on the shared Key Vault. Once enabled, deleted Key Vault contents cannot be permanently removed for 7 days and the setting cannot be turned off retroactively. Recommended for production. This shared module defaults to false; Foundation exposes it as an opt-in, while Expanded Platform enables it for the management Key Vault.')
@@ -64,7 +64,7 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = if (c
   }
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = if (createKeyVault) {
+resource keyVault 'Microsoft.KeyVault/vaults@2026-02-01' = if (createKeyVault) {
   name: keyVaultName
   location: primaryLocation
   tags: mergedTags
@@ -73,6 +73,15 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = if (createKeyVault) {
     enablePurgeProtection: enableKeyVaultPurgeProtection ? true : null
     enableSoftDelete: true
     publicNetworkAccess: keyVaultPublicNetworkAccess
+    // The empty allowlists are intentional and deployment-owned: the default
+    // data plane stays sealed. Redeployment removes manually added allow rules;
+    // use the supported private endpoint path for durable network access.
+    networkAcls: {
+      bypass: 'None'
+      defaultAction: 'Deny'
+      ipRules: []
+      virtualNetworkRules: []
+    }
     sku: {
       family: 'A'
       name: 'standard'

--- a/AzureLandingZoneforNonprofits/infra/modules/shared/subscription-platform-slice.bicep
+++ b/AzureLandingZoneforNonprofits/infra/modules/shared/subscription-platform-slice.bicep
@@ -35,7 +35,7 @@ param createKeyVault bool = true
 @description('Optional stable seed for the generated Key Vault name. Leave empty to preserve the default deterministic name; set a custom value only when an evaluation deployment must avoid a soft-deleted Key Vault name in the same resource group.')
 param keyVaultNameSeed string = ''
 
-@description('Public network access mode for the shared Key Vault.')
+@description('Public endpoint mode for the shared Key Vault. The shared resource baseline always applies a deny-by-default firewall; private endpoint deployments set this to Disabled.')
 param keyVaultPublicNetworkAccess 'Enabled' | 'Disabled' = 'Enabled'
 
 @description('Enable purge protection on the slice Key Vault. Defaults to false in this shared module; Foundation exposes this as an opt-in, while Expanded Platform enables it for the management Key Vault.')

--- a/AzureLandingZoneforNonprofits/scenarios.json
+++ b/AzureLandingZoneforNonprofits/scenarios.json
@@ -28,6 +28,11 @@
           "requiresExplicitApproval": false
         },
         {
+          "parameter": "enableSimpleNetwork",
+          "message": "The Foundation application subnet uses a network security group that blocks internet ingress and egress. Before deploying workloads, add only the required higher-priority allow rules and an explicit outbound method. Before rerunning against an existing Foundation VNet, review and migrate any existing subnet rules and traffic dependencies to avoid interruption.",
+          "requiresExplicitApproval": false
+        },
+        {
           "parameter": "enablePrivateDnsAndEndpoints",
           "message": "Private connectivity changes the platform access model and may require extra DNS configuration.",
           "requiresExplicitApproval": false


### PR DESCRIPTION
## Summary

- Sync the public CLI package with the latest Azure Landing Zone security baseline.
- Apply deny-by-default Key Vault network ACLs to Foundation and Expanded Platform.
- Add an NSG to the Foundation application subnet and serialize subnet updates before Private Endpoint creation.
- Expose the new networking outputs and operator warnings through the installer.

## Validation

- Confirmed the public package matches the generated source package.
- Validated PowerShell and JSON syntax.
- Compiled all 22 distributed Bicep files successfully.
